### PR TITLE
build: fix npm config warnings by moving publish settings and removin…

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-npmPublishRegistry: https://registry.npmjs.org
-npmPublishAccess: "public"
-nodeLinker: "node-modules"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "design",
     "typescript"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
   "scripts": {
     "clean": "rm -rf ./dist",
     "build": "pnpm run clean && tsc",


### PR DESCRIPTION
…g .npmrc

- Moved npmPublishRegistry and npmPublishAccess to publishConfig in package.json.
- Removed .npmrc to resolve nodeLinker warnings and cleanup configuration.